### PR TITLE
Fix import statements

### DIFF
--- a/pyorbit/__init__.py
+++ b/pyorbit/__init__.py
@@ -1,2 +1,2 @@
-from device import Device
-from exception import ConnectError
+from .device import Device
+from .exception import ConnectError

--- a/pyorbit/services/__init__.py
+++ b/pyorbit/services/__init__.py
@@ -1,2 +1,2 @@
-from config import Config
+from .config import Config
 #from fw import Firmware

--- a/pyorbit/services/config.py
+++ b/pyorbit/services/config.py
@@ -5,7 +5,7 @@ from jinja2 import Template
 from lxml import etree
 
 # package modules
-from service import Service
+from .service import Service
 from pyorbit.exception import *
 
 """


### PR DESCRIPTION
Importing modules from the same directory require a period before the
module name.